### PR TITLE
Fix 404 errors for rest routes

### DIFF
--- a/assets/css/snappic-welcome.css
+++ b/assets/css/snappic-welcome.css
@@ -236,6 +236,9 @@ body{
   width: 20px;
   top: 4px;
 }
+.permalink_error {
+    margin-top: 2em;
+}
 .subtitle{
   text-transform: uppercase;
   color: #25c8d4;

--- a/assets/js/snappic-welcome.js
+++ b/assets/js/snappic-welcome.js
@@ -11,15 +11,20 @@ jQuery( function ( $ ) {
 
 		$.ajax
 		    ({ 
-		        url: snappic_for_woocommerce.permalink_url,
+		        url: snappic_for_woocommerce.ajaxurl,
 		        type: 'post',
-		        beforeSend: function ( xhr ) {
-        			xhr.setRequestHeader( 'X-WP-Nonce', snappic_for_woocommerce.nonce );
-    			},
-		        success: function(result)
+		        data: {
+					'action': 'snappic_update_permalinks',
+					'nonce': snappic_for_woocommerce.nonce
+				},
+		        success: function(response)
 		        {
 		        	$_this.removeClass('loading').prop('disabled', true);
-		            $slides.addClass( 'pick_plan' );
+		        	if( response == 1 ) {
+		            	$slides.addClass( 'pick_plan' );
+		        	} else {
+		        		$('#change_url_structure .permalink_error').slideDown();
+		        	}
 		        }
 		    });
 

--- a/includes/admin/views/html-snappic-welcome.php
+++ b/includes/admin/views/html-snappic-welcome.php
@@ -34,6 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
         <h2 class="h2"><?php _e( 'Looks like we have to switch your URL structure from “Plain” to “Post Name”', 'snappic-for-woocommerce' );?></h2>
         <div class="subtitle"><?php _e( 'THIS ALLOWS US TO SYNC UP WITH YOUR INVENTORY AND STOP SHOWING ADS FOR PRODUCTS ONCE THEY ARE OUT OF STOCK', 'snappic-for-woocommerce' );?></div>
         <a href='#pick_plan' class="button-blue js-goto update-permalink" data-goto="pick_plan"><?php _e( 'Change and Continue', 'snappic-for-woocommerce' );?></a>
+        <div class="permalink_error" style="display:none;"><p><?php _e( 'Sorry, we were not able to update your permalinks at this time.', 'snappic-for-woocommerce' );?></p></div>
         <div class="note"><?php _e( 'This won’t change how your website looks or any of your products', 'snappic-for-woocommerce' );?></div>
       </div>
       <!-- end content -->

--- a/includes/class-snappic-admin-setup-wizard.php
+++ b/includes/class-snappic-admin-setup-wizard.php
@@ -47,8 +47,8 @@ class Snappic_Admin_Setup_Wizard {
 		wp_enqueue_script( 'snappic-welcome', Snappic_Base::get_instance()->plugin_url() . '/assets/js/snappic-welcome.js', array( 'jquery' ), Snappic_Base::VERSION, true );
 
 		$l10n = array( 
-			'nonce' => wp_create_nonce( 'wp_rest' ),
-			'permalink_url' => esc_url_raw( rest_url( 'wc/v1/snappic/store/update' ) ),
+			'nonce' => wp_create_nonce( 'snappic_update' ),
+			'ajaxurl' => admin_url( 'admin-ajax.php' ),
 			 );
 		wp_localize_script( 'snappic-welcome', 'snappic_for_woocommerce ', $l10n );
 

--- a/includes/class-snappic-api-controller.php
+++ b/includes/class-snappic-api-controller.php
@@ -33,22 +33,6 @@ class Snappic_API_Controller extends WP_REST_Controller {
       'schema' => array( $this, 'get_public_item_schema' ),
     ) );
 
-    register_rest_route( $this->namespace, '/' . $this->rest_base . '/update', array(
-      array(
-        'methods'             => WP_REST_Server::EDITABLE,
-        'callback'            => array( $this, 'update_permalinks' ),
-        'permission_callback' => array( $this, 'update_permalinks_permissions_check' ),
-      )
-    ) );
-
-    register_rest_route( $this->namespace, '/' . $this->rest_base . '/signup', array(
-      array(
-        'methods'             => WP_REST_Server::EDITABLE,
-        'callback'            => array( $this, 'get_signup_link' ),
-        'permission_callback' => array( $this, 'update_permalinks_permissions_check' ),
-      )
-    ) );
-
   }
  
   /**
@@ -101,11 +85,14 @@ class Snappic_API_Controller extends WP_REST_Controller {
   /**
    * Makes sure the current user has access to WRITE the settings APIs.
    *
-   * @since  3.0.0
+   * @since  1.0.0
+   * @deprecated 1.1.0
+   * 
    * @param WP_REST_Request $request Full data about the request.
    * @return WP_Error|boolean
    */
-  public function update_permalinks_permissions_check( $request ) {
+  public function update_permalinks_permissions_check( $request ) { 
+    _deprecated_function( 'WC_Free_Gift_Coupons::update_permalinks', '1.1.0', 'Snappic_Base::update_permalinks()' );
     if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
       return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit the permalinks.', 'snappic-for-woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
     }
@@ -115,12 +102,16 @@ class Snappic_API_Controller extends WP_REST_Controller {
 
   /**
    * Check whether a given request has permission to read data.
+   * 
+   * @since 1.0.0 
+   * @deprecated 1.1.0 - process now occurs via AJAX callback, see Snappic_Base::update_permalinks()
    *
    * @param  WP_REST_Request $request Full details about the request.
    * @return WP_Error|boolean
    */
   public function update_permalinks( $request ) {
-    $data = array( 'status' => update_option( 'permalink_structure', "/%postname%/" ) );
+    _deprecated_function( 'WC_Free_Gift_Coupons::update_permalinks', '1.1.0', 'Snappic_Base::update_permalinks()' );
+    $data = array( 'status' => update_option( 'permalink_structure', "/%year%/%monthnum%/%postname%/" ) );
     flush_rewrite_rules();
     return rest_ensure_response( $data );
   }

--- a/snappic-for-woocommerce.php
+++ b/snappic-for-woocommerce.php
@@ -65,6 +65,9 @@ class Snappic_Base {
 
         // Register API endpoint
         add_filter( 'rest_api_init', array( $this, 'add_api_resource' ) );
+        
+        // Ajax callback for updating permalinks
+        add_action( 'wp_ajax_snappic_update_permalinks', array( $this, 'update_permalinks' ) );
 
         /*
          * Save routine workaround
@@ -338,6 +341,36 @@ class Snappic_Base {
 
     }
 
+
+    /**
+     * Update the Permalinks via AJAX
+     * Using an AJAX callback is preferred to using a REST route because it ensures that the functions that write the HTACCESS are available.
+     *
+     * @return string json-encoded
+     */
+    public function update_permalinks() {
+        
+        global $wp_rewrite;
+        
+        error_log(json_encode($wp_rewrite));
+        
+        $permalink_structure = "/%postname%/";
+	
+		if ( ! isset( $_POST[ 'nonce' ] ) || ! wp_verify_nonce( $_POST[ 'nonce' ], 'snappic_update' ) ) {
+			wp_die();
+		}
+ 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die();
+		}
+        
+        $wp_rewrite->set_permalink_structure( $permalink_structure );
+        flush_rewrite_rules();
+        wp_die('1');
+        
+    }
+  
+  
     /*-----------------------------------------------------------------------------------*/
     /*  Helpers                                                                   */
     /*-----------------------------------------------------------------------------------*/

--- a/snappic-for-woocommerce.php
+++ b/snappic-for-woocommerce.php
@@ -283,7 +283,7 @@ class Snappic_Base {
         $locale = apply_filters( 'plugin_locale', $locale, 'snappic' );
 
         unload_textdomain( 'snappic' );
-        load_plugin_textdomain( 'snappic', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
+        load_plugin_textdomain( 'snappic-for-woocommerce', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
     }
 
 


### PR DESCRIPTION
>When installing the Snappic extension into a WooCommerce store, the "permalink structure" change is changed by the extension, but is not reflected by the webserver.

This was quite the rabbit hole, but while the permalink structure option was updated and the rewrite rules flushed [here](https://github.com/AltoLabs/snappic-woocommerce/blob/master/includes/class-snappic-api-controller.php#L123-L124) the new .htaccess was not being generated, thus the 404. 

The TLDR of why the .htaccess didn't change is twofold. 

1) when attempted via the REST route, the functions that write the .htaccess file aren't loaded. They *are* loaded when access `admin-ajax.php` so I have switched to a regular, non-REST ajax callback. 

2) once that was resolved, I found that the `WP_Rewrite` class stores a copy of the permalink structure as a class property. If that property doesn't change, `flush_rewrite_rules()` basically thinks the rules are the same and won't generate the new rules. 

To resolve this, I've accessed the global `$wp_rewrite` and used the `set_permalink_structure()` method  [here](https://github.com/AltoLabs/snappic-woocommerce/compare/master...helgatheviking:master#diff-07f4d8f87e66c72117b74477843714cdR367). 

NB: I'm reading that `%post_name%` may be inefficient as the permalink structure if the site has lots of content. It may be better to begin with numbers ie: `/%year%/%monthnum%/%postname%/`. [Source](https://digwp.com/2011/06/dont-use-postname/) But I'll leave that decision to you. 

I removed the `/wp-json/wc/v1/snappic/store/update` route and the `/wp-json/wc/v1/snappic/store/signup` routes. The former is no longer needed, and I don't think the latter has been in use since release. 

I also fixed the textdomain which didn't match what was being used throughout the plugin. 

Now, the `/wp-json/wc/v1/snappic/store` route does not 404 immediately after the "change permalinks" button is clicked. 



