### PR TITLE
Check for correct API keys when requesting the signup URL and only store valid API keys

### DIFF
--- a/includes/class-snappic-helper.php
+++ b/includes/class-snappic-helper.php
@@ -208,6 +208,10 @@ class Snappic_Helper {
      */
     public function get_signup_url($plan = '') {
         $settings = Snappic_Integration::instance();
+
+        // Check if API keys are correctly set.
+        $settings->check_api_keys();
+
         $consumerKey = $settings->get_option('cust_key');
         $consumerSecret = $settings->get_option('cust_secret');
         $query_args = array(

--- a/snappic-for-woocommerce.php
+++ b/snappic-for-woocommerce.php
@@ -154,30 +154,10 @@ class Snappic_Base {
      * Delay the keygen until shutdown.
      */
     public function delayed_install() {
-
         if( ! $this->helper->get_stored_pixel_id() ) {
-
-            update_option( 'woocommerce_api_enabled', 'yes' );
-
-            include_once( 'includes/class-snappic-auth.php' );
-            $snappicAuth = new Snappic_Auth();
-            $domain = $this->helper->get_site_domain();
-            $result = $snappicAuth->generate_keys( __( 'Snappic', 'snappic-for-woocommerce' ), $domain, 'read' );
-
-            if( ! is_wp_error( $result ) ) {
-
-                $updated_options = array(
-                    'key_id' => $result['key_id'],
-                    'cust_key' => $result['consumer_key'],
-                    'cust_secret'   => $result['consumer_secret'],
-                    'cleanup'   => 'yes'
-                );
-
-                $this->helper->update_options( $updated_options );
-            }
-
+            $settings = Snappic_Integration::instance();
+            $settings->set_api_keys();
         }
-
     }
 
 


### PR DESCRIPTION
Method generate_keys() doesn't return a WP_Error object on failure. Still kept it for future code changes and added checking for the values. Now we also check and generate API keys when the signup URL is requested.

I looked over the code base and the only reason why I see the API keys wouldn't got generated was because WooCommerce wasn't activated before Snappic got activated. This is now fixed since using`get_signup_url()` will result in the generation of the API keys